### PR TITLE
[hosts.example] ansible_ssh_host/user -> ansible_host/user

### DIFF
--- a/hosts.example
+++ b/hosts.example
@@ -1,21 +1,21 @@
 [ydbd_static]
-ycydb-s1 ansible_ssh_host=ycydb-s1 ansible_ssh_user=yc-user
-ycydb-s2 ansible_ssh_host=ycydb-s2 ansible_ssh_user=yc-user
-ycydb-s3 ansible_ssh_host=ycydb-s3 ansible_ssh_user=yc-user
-ycydb-s4 ansible_ssh_host=ycydb-s4 ansible_ssh_user=yc-user
-ycydb-s5 ansible_ssh_host=ycydb-s5 ansible_ssh_user=yc-user
-ycydb-s6 ansible_ssh_host=ycydb-s6 ansible_ssh_user=yc-user
-ycydb-s7 ansible_ssh_host=ycydb-s7 ansible_ssh_user=yc-user
-ycydb-s8 ansible_ssh_host=ycydb-s8 ansible_ssh_user=yc-user
-ycydb-s9 ansible_ssh_host=ycydb-s9 ansible_ssh_user=yc-user
+ycydb-s1 ansible_host=ycydb-s1 ansible_user=yc-user
+ycydb-s2 ansible_host=ycydb-s2 ansible_user=yc-user
+ycydb-s3 ansible_host=ycydb-s3 ansible_user=yc-user
+ycydb-s4 ansible_host=ycydb-s4 ansible_user=yc-user
+ycydb-s5 ansible_host=ycydb-s5 ansible_user=yc-user
+ycydb-s6 ansible_host=ycydb-s6 ansible_user=yc-user
+ycydb-s7 ansible_host=ycydb-s7 ansible_user=yc-user
+ycydb-s8 ansible_host=ycydb-s8 ansible_user=yc-user
+ycydb-s9 ansible_host=ycydb-s9 ansible_user=yc-user
 
 [ydbd_dynamic]
-ycydb-s1 ansible_ssh_host=ycydb-s1 ansible_ssh_user=yc-user
-ycydb-s2 ansible_ssh_host=ycydb-s2 ansible_ssh_user=yc-user
-ycydb-s3 ansible_ssh_host=ycydb-s3 ansible_ssh_user=yc-user
-ycydb-s4 ansible_ssh_host=ycydb-s4 ansible_ssh_user=yc-user
-ycydb-s5 ansible_ssh_host=ycydb-s5 ansible_ssh_user=yc-user
-ycydb-s6 ansible_ssh_host=ycydb-s6 ansible_ssh_user=yc-user
-ycydb-s7 ansible_ssh_host=ycydb-s7 ansible_ssh_user=yc-user
-ycydb-s8 ansible_ssh_host=ycydb-s8 ansible_ssh_user=yc-user
-ycydb-s9 ansible_ssh_host=ycydb-s9 ansible_ssh_user=yc-user
+ycydb-s1 ansible_host=ycydb-s1 ansible_user=yc-user
+ycydb-s2 ansible_host=ycydb-s2 ansible_user=yc-user
+ycydb-s3 ansible_host=ycydb-s3 ansible_user=yc-user
+ycydb-s4 ansible_host=ycydb-s4 ansible_user=yc-user
+ycydb-s5 ansible_host=ycydb-s5 ansible_user=yc-user
+ycydb-s6 ansible_host=ycydb-s6 ansible_user=yc-user
+ycydb-s7 ansible_host=ycydb-s7 ansible_user=yc-user
+ycydb-s8 ansible_host=ycydb-s8 ansible_user=yc-user
+ycydb-s9 ansible_host=ycydb-s9 ansible_user=yc-user


### PR DESCRIPTION
It looks like `ansible_ssh_host` has been deprecated in 2016:
![Screenshot 2023-11-06 at 11 20 34](https://github.com/ydb-platform/ydb-ansible/assets/623861/11f979c4-7f57-496f-9897-d9d70d561db4)
https://www.ansible.com/blog/ansible-2.0-launch