### PR TITLE
Fix ydb_dynamic systemd unit template

### DIFF
--- a/roles/ydbd_dynamic/templates/ydbd-dynnode.service
+++ b/roles/ydbd_dynamic/templates/ydbd-dynnode.service
@@ -17,7 +17,6 @@ ExecStart={{ ydb_dir }}/bin/ydbd server \
     --mon-port {{ 8766 + item.offset }} --mon-cert {{ ydb_dir }}/certs/web.pem \
     --tenant /{{ ydb_domain }}/{{ ydb_dbname }} \
 {% for ydb_broker in ydb_brokers %}
-
     --node-broker grpcs://{{ ydb_broker }}:2135{% if not loop.last %} \{% endif %}
 {% endfor %}
 


### PR DESCRIPTION
[Bugfix] /etc/systemd/system/ydbd-database-b.service was generated with empty line in ydbd cmdline arguments.
Ubuntu systemd ignore empty lines.
 