### PR TITLE
YDBDOCS-690: introduce restart.yaml playbook

### DIFF
--- a/playbooks/restart.yaml
+++ b/playbooks/restart.yaml
@@ -1,0 +1,10 @@
+- hosts: "{{ playbook_hosts | default('ydb') }}"
+  roles:
+  - role: ydbd_rolling_static
+    tags:
+      - storage
+      - static
+  - role: ydbd_rolling_dynamic
+    tags:
+      - database
+      - dynamic

--- a/plugins/module_utils/cli.py
+++ b/plugins/module_utils/cli.py
@@ -135,3 +135,38 @@ class DsTool(CLI):
             self.common_environ['YDB_TOKEN'] = token
         elif token_file is not None:
             self.common_options.extend(['--token-file', token_file])
+
+
+class YdbOps(CLI):
+    argument_spec = dict(
+        ydbops_bin=dict(type='str', default=None),
+        ydbops_endpoint=dict(type='str', default=None),
+        ydbops_systemd_unit=dict(type='str', default='ydbd-storage'),
+        ca_file=dict(type='str', default=None),
+        ssh_args=dict(type='str', default=None),
+        availability_mode=dict(type='str', default='strong'),
+        token=dict(type='str', default=None, no_log=True),
+        token_file=dict(type='str', default=None)
+    )
+
+    def __init__(self, module, ydbops_bin, ydbops_endpoint, ydbops_systemd_unit=None,
+                 ca_file=None, ssh_args=None, availability_mode=None, token=None, token_file=None):
+        self.module = module
+
+        self.common_options = [ydbops_bin, 'restart', '--storage']
+        self.common_environ = {}
+
+        if ydbops_endpoint is not None:
+            self.common_options.extend(['--endpoint', ydbops_endpoint])
+        if ca_file is not None:
+            self.common_options.extend(['--ca-file', ca_file])
+        if ssh_args is not None:
+            self.common_options.extend(['--ssh-args', ssh_args])
+        if ydbops_systemd_unit is not None:
+            self.common_options.extend(['--systemd-unit', ydbops_systemd_unit])
+        if availability_mode is not None:
+            self.common_options.extend(['--availability-mode', availability_mode])
+        if token is not None:
+            self.common_environ['YDB_TOKEN'] = token
+        elif token_file is not None:
+            self.common_options.extend(['--token-file', token_file])

--- a/plugins/modules/restart_storage.py
+++ b/plugins/modules/restart_storage.py
@@ -1,0 +1,28 @@
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.ydb_platform.ydb.plugins.module_utils import cli
+
+
+def main():
+    argument_spec=dict(
+        timeout=dict(type='int', default=180),
+    )
+    cli.YdbOps.add_arguments(argument_spec)
+    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=False)
+    result = {'changed': False}
+    try:
+        ydbops_cli = cli.YdbOps.from_module(module)
+        module.log(f'running {ydbops_cli.common_options}')
+        rc, stdout, stderr = ydbops_cli([])
+        result['msg'] = f'ydbops status — rc: {rc}, stdout: {stdout}, stderr: {stderr}'
+        if rc == 0:
+            module.exit_json(**result)
+        else:
+            module.fail_json(**result)
+
+    except Exception as e:
+        result['msg'] = f'unexpected exception: {e}'
+        module.fail_json(**result)
+
+
+if __name__ == '__main__':
+    main()

--- a/roles/ydbd_rolling_dynamic/tasks/main.yaml
+++ b/roles/ydbd_rolling_dynamic/tasks/main.yaml
@@ -2,8 +2,8 @@
 # ydbd dynamic nodes rolling restart
 
 - name: YDB database nodes rolling restart
-  include_tasks: "restart_dynamic.yml"
-  loop: "{{ groups['ydbd_dynamic']|flatten(levels=1) }}"
+  include_tasks: "restart_dynamic.yaml"
+  loop: "{{ groups['ydbd_dynamic'] | default(groups['all']) | flatten(levels=1) }}"
   loop_control:
     loop_var: dynnode_name
   run_once: true

--- a/roles/ydbd_rolling_dynamic/tasks/restart_dynamic.yaml
+++ b/roles/ydbd_rolling_dynamic/tasks/restart_dynamic.yaml
@@ -10,23 +10,18 @@
   delegate_facts: true
   loop: "{{ ydb_dynnodes }}"
   any_errors_fatal: true
+  become: true
+  become_method: sudo
+  become_user: root
 
-- name: Transfer the secrets to {{ dynnode_name }}
-  copy: src=secret dest={{ ydb_dir }}/certs/secret
-  delegate_to: "{{ dynnode_name }}"
-  delegate_facts: true
-  any_errors_fatal: true
-
-- name: Wait for the dynamic nodes to come up
-  command: "sudo -u ydb {{ ydb_dir }}/home/wait_dynamic.sh {{ inventory_hostname }} {{ 2136 + item.offset }} {{ ydb_dbname }}"
-  delegate_to: "{{ dynnode_name }}"
-  delegate_facts: true
+- name: Wait for dynamic nodes on {{ dynnode_name }} to start listening
+  ansible.builtin.wait_for:
+    port: "{{ 2136 + offset }}"
+    delay: 3
+    sleep: 3
   loop: "{{ ydb_dynnodes }}"
-
-- name: Cleanup the transferred secrets at {{ dynnode_name }}
-  file: state=absent path={{ ydb_dir }}/certs/secret
-  delegate_to: "{{ dynnode_name }}"
-  delegate_facts: true
+  loop_control:
+    index_var: offset
 
 - name: Additional delay to settle the dynamic nodes
-  ansible.builtin.pause: seconds={{ ydb_dynnode_restart_sleep_seconds }}
+  ansible.builtin.pause: seconds={{ ydb_dynnode_restart_sleep_seconds | default(5) }}

--- a/roles/ydbd_rolling_static/tasks/check_static.yaml
+++ b/roles/ydbd_rolling_static/tasks/check_static.yaml
@@ -1,13 +1,5 @@
 ---
-# YDB single static node restart tasks
-
-- name: restart the storage node at {{ snode_name }}
-  ansible.builtin.systemd:
-    state: restarted
-    name: ydbd-storage
-  delegate_to: "{{ snode_name }}"
-  delegate_facts: true
-  any_errors_fatal: true
+# YDB check static node tasks
 
 - name: wait for ydb discovery to start working locally
   ydb_platform.ydb.wait_discovery:

--- a/roles/ydbd_rolling_static/tasks/main.yaml
+++ b/roles/ydbd_rolling_static/tasks/main.yaml
@@ -27,7 +27,7 @@
   delegate_to: 127.0.0.1
   run_once: true
   ansible.builtin.get_url:
-    url: https://storage.yandexcloud.net/blinkov-tmp/ydbops # TODO: release with a release URL
+    url: https://storage.yandexcloud.net/blinkov-tmp/ydbops # TODO: replace with a release URL
     dest: "{{ ansible_config_file | dirname }}/bin/"
     mode: 0755
 

--- a/roles/ydbd_rolling_static/tasks/main.yaml
+++ b/roles/ydbd_rolling_static/tasks/main.yaml
@@ -16,9 +16,34 @@
   retries: 10
   delay: 10
 
-- name: ydb storage rolling restart
-  include_tasks: "restart_static.yaml"
-  loop: "{{ groups['ydb']|flatten(levels=1) }}"
+- name: create bin directory
+  delegate_to: 127.0.0.1
+  run_once: true
+  ansible.builtin.file:
+    path: "{{ ansible_config_file | dirname }}/bin/"
+    state: directory
+
+- name: install ydbops
+  delegate_to: 127.0.0.1
+  run_once: true
+  ansible.builtin.get_url:
+    url: https://storage.yandexcloud.net/blinkov-tmp/ydbops # TODO: release with a release URL
+    dest: "{{ ansible_config_file | dirname }}/bin/"
+    mode: 0755
+
+- name: "run ydbops to gracefully restart the cluster, it takes a long time"
+  delegate_to: 127.0.0.1
+  run_once: true
+  ydb_platform.ydb.restart_storage:
+    ydbops_bin: "{{ ansible_config_file | dirname }}/bin/ydbops"
+    ydbops_endpoint: "grpcs://{{ groups['ydb'] | default(groups['all']) | flatten(levels=1) | first }}.:2135"
+    ssh_args: "ssh -l {{ ansible_user }} -i {{ ansible_ssh_private_key_file }} -o StrictHostKeyChecking=no -o ProxyCommand=\\\"ssh -W %h:%p -i {{ ansible_ssh_private_key_file }} {{ ansible_user }}@{{ groups['ydb'] | default(groups['all']) | flatten(levels=1) | first }}\\\""
+    ca_file: "{{ ansible_config_file | dirname }}/../TLS/CA/certs/ca.crt"
+    token: "{{ ydb_credentials.token }}"
+
+- name: ydb storage check
+  include_tasks: "check_static.yaml"
+  loop: "{{ groups['ydb'] | default(groups['all']) | flatten(levels=1) }}"
   loop_control:
     loop_var: snode_name
   run_once: true


### PR DESCRIPTION
Introduce a `restart.yaml` playbook that properly restarts the whole cluster by default.
Using `--tags static` or `--tags dynamic`, restart can be limited to a respective subset of nodes.

For static nodes, it leverages https://github.com/ydb-platform/ydbops to ensure smooth restarts that do not jeopardize availability.
Compatible with https://ydb.tech/docs/en/devops/ansible/initial-deployment