### PR TITLE
KIKIMR-20945: optionally import inventory from a file produced by ydb-terraform

### DIFF
--- a/playbooks/factory_ipmi_power_reset.yaml
+++ b/playbooks/factory_ipmi_power_reset.yaml
@@ -1,5 +1,8 @@
+- hosts: localhost
+  roles:
+  - role: inventory_hosts
 - name: playbook to perform ipmi power reset on YDB appliance factory
-  hosts: ydb
+  hosts: "{{ playbook_hosts | default('ydb') }}"
   tasks:
     - name: send ipmi reset command
       shell: ipmitool -H {{ factory_ipmi_ip_address }} -U {{ factory_ipmi_user }} -P {{ factory_ipmi_password }} power reset

--- a/playbooks/factory_setup.yaml
+++ b/playbooks/factory_setup.yaml
@@ -1,5 +1,8 @@
+- hosts: localhost
+  roles:
+  - role: inventory_hosts
 - name: setup YDB on appliance factory
-  hosts: ydb
+  hosts: "{{ playbook_hosts | default('ydb') }}"
   become: true
   tasks:
     - name: setup ipv4 connectivity

--- a/playbooks/initial_setup.yaml
+++ b/playbooks/initial_setup.yaml
@@ -1,4 +1,7 @@
-- hosts: ydb
+- hosts: localhost
+  roles:
+  - role: inventory_hosts
+- hosts: "{{ playbook_hosts | default('ydb') }}"
   become: true
   tasks:
     - name: setup packages

--- a/playbooks/install_dynamic.yaml
+++ b/playbooks/install_dynamic.yaml
@@ -1,3 +1,6 @@
+- hosts: localhost
+  roles:
+  - role: inventory_hosts
 - hosts: "{{ playbook_hosts | default('ydb') }}"
   tasks:
     - name: setup ydb dynamic nodes

--- a/playbooks/install_static.yaml
+++ b/playbooks/install_static.yaml
@@ -1,3 +1,6 @@
+- hosts: localhost
+  roles:
+  - role: inventory_hosts
 - hosts: "{{ playbook_hosts | default('ydb') }}"
   tasks:
     - name: setup ydb static nodes

--- a/playbooks/logs.yaml
+++ b/playbooks/logs.yaml
@@ -1,6 +1,9 @@
 ---
+- hosts: localhost
+  roles:
+  - role: inventory_hosts
 - name: Get logs of YDB nodes
-  hosts: ydb
+  hosts: "{{ playbook_hosts | default('ydb') }}"
   tasks:
     - name: Fetch storage nodes logs
       shell: journalctl -u ydbd-storage

--- a/playbooks/restart.yaml
+++ b/playbooks/restart.yaml
@@ -1,3 +1,6 @@
+- hosts: localhost
+  roles:
+  - role: inventory_hosts
 - hosts: "{{ playbook_hosts | default('ydb') }}"
   roles:
   - role: ydbd_rolling_static

--- a/playbooks/rolling_restart_dynamic.yaml
+++ b/playbooks/rolling_restart_dynamic.yaml
@@ -1,3 +1,6 @@
+- hosts: localhost
+  roles:
+  - role: inventory_hosts
 - hosts: "{{ playbook_hosts | default('ydb') }}"
   roles:
   - role: ydbd_rolling_dynamic

--- a/playbooks/site_connectivity.yaml
+++ b/playbooks/site_connectivity.yaml
@@ -1,5 +1,8 @@
+- hosts: localhost
+  roles:
+  - role: inventory_hosts
 - name: setup YDB connectivity on site
-  hosts: ydb
+  hosts: "{{ playbook_hosts | default('ydb') }}"
   become: true
   tasks:
     - name: setup ipv4 connectivity

--- a/playbooks/site_setup.yaml
+++ b/playbooks/site_setup.yaml
@@ -1,5 +1,8 @@
+- hosts: localhost
+  roles:
+  - role: inventory_hosts
 - name: setup YDB on site
-  hosts: ydb
+  hosts: "{{ playbook_hosts | default('ydb') }}"
   become: true
   tasks:
     - name: setup packages

--- a/playbooks/update_config.yaml
+++ b/playbooks/update_config.yaml
@@ -1,3 +1,6 @@
+- hosts: localhost
+  roles:
+  - role: inventory_hosts
 - name: check if required variables are defined
   hosts: "{{ playbook_hosts | default('ydb') }}"
   tasks:

--- a/roles/inventory_hosts/tasks/main.yaml
+++ b/roles/inventory_hosts/tasks/main.yaml
@@ -1,0 +1,8 @@
+- name: Import extra inventory hosts from ydb_hosts_list is defined
+  when: ydb_hosts_list is defined
+  block:
+  - name: Add each hostname to inventory
+    ansible.builtin.add_host:
+      name: "{{ item }}"
+      group: "{{ playbook_hosts | default('ydb') }}"
+    loop: "{{ lookup('file', ydb_hosts_list).splitlines() }}"


### PR DESCRIPTION
https://github.com/ydb-platform/ydb-terraform produces a simple file with one FQDN of created VM per line, for example:
```
$ cat hosts.txt
static-node-1.ydb-cluster.com
static-node-2.ydb-cluster.com
static-node-3.ydb-cluster.com
```