### PR TITLE
Skip install if binary is present

### DIFF
--- a/roles/install_ydbd/defaults/main.yaml
+++ b/roles/install_ydbd/defaults/main.yaml
@@ -3,3 +3,5 @@ ydb_libidn_archive_unpack_options: ['--strip-component=1']
 ydb_archive_unpack_options: ['--strip-component=1']
 
 ydb_repo_url: https://github.com/ydb-platform/ydb.git
+
+ydb_force_update: false

--- a/roles/install_ydbd/tasks/install_ydb_from_archive.yaml
+++ b/roles/install_ydbd/tasks/install_ydb_from_archive.yaml
@@ -10,3 +10,4 @@
     owner: root
     group: root
     extra_opts: "{{ ydb_archive_unpack_options }}"
+  when: not ydbd_stat.stat.exists|bool or ydb_force_update|bool

--- a/roles/install_ydbd/tasks/install_ydb_from_source.yaml
+++ b/roles/install_ydbd/tasks/install_ydb_from_source.yaml
@@ -14,6 +14,11 @@
   ansible.builtin.set_fact:
     ydb_cli_binary: "{{ ydb_git_path }}/ydb/apps/ydb/ydb"
 
+- name: check if ydbd present
+  stat:
+    path: "{{ ydb_dir }}/bin/ydbd"
+  register: ydbd_stat
+
 - name: Prepare binaries
   delegate_to: 127.0.0.1
   become: false
@@ -33,3 +38,4 @@
 
     - name: Build YDB CLI from source code (it might take a long time)
       ansible.builtin.shell: "{{ ydb_ya_path }} make {{ ydb_git_path }}/ydb/apps/ydb --build release"
+  when: not ydbd_stat.stat.exists|bool or ydb_force_update|bool

--- a/roles/install_ydbd/tasks/install_ydb_from_version.yaml
+++ b/roles/install_ydbd/tasks/install_ydb_from_version.yaml
@@ -1,3 +1,8 @@
+- name: check if ydbd present
+  stat:
+    path: "{{ ydb_dir }}/bin/ydbd"
+  register: ydbd_stat
+
 - name: Set local path to ydb_archive_dest variable
   set_fact:
     ydb_archive_dest: "{{ ansible_config_file | dirname }}/files/"
@@ -11,7 +16,9 @@
   ansible.builtin.get_url:
     url: "https://binaries.ydb.tech/release/{{ ydb_version }}/ydbd-{{ ydb_version }}-linux-amd64.tar.gz"
     dest: "{{ ydb_archive_dest }}"
+  when: not ydbd_stat.stat.exists|bool or ydb_force_update|bool
 
 - name: install YDB server binary package from a downloaded archive
   import_tasks:
     file: install_ydb_from_archive.yaml
+  when: not ydbd_stat.stat.exists|bool or ydb_force_update|bool

--- a/roles/install_ydbd/tasks/install_ydb_using_binary.yaml
+++ b/roles/install_ydbd/tasks/install_ydb_using_binary.yaml
@@ -6,6 +6,11 @@
     group: root
     mode: 0755
 
+- name: check if ydbd present
+  stat:
+    path: "{{ ydb_dir }}/bin/ydbd"
+  register: ydbd_stat
+
 - name: copy YDB server binary file
   ansible.builtin.copy:
     src: "{{ ydbd_binary }}"
@@ -14,6 +19,7 @@
     mode: 0755
     follow: true
     checksum: no
+  when: not ydbd_stat.stat.exists|bool or ydb_force_update|bool
 
 - name: copy YDB cli binary file
   ansible.builtin.copy:


### PR DESCRIPTION
There's no need to reinstall binaries if we have it.
Update is the only one case for such situation and I've added variable 'ydb_force_update' to force this action.