### PR TITLE
ydbd_rolling_static make ansible_ssh_common_args optional

### DIFF
--- a/roles/ydbd_rolling_static/defaults/main.yaml
+++ b/roles/ydbd_rolling_static/defaults/main.yaml
@@ -12,3 +12,4 @@ ydb_enforce_user_token_requirement: true
 
 ydbops_release_url: https://github.com/ydb-platform/ydbops/releases/latest/download
 
+ansible_ssh_common_args: ""


### PR DESCRIPTION
Add reasonable default for ansible_ssh_common_args in ydbd_rolling_static