### PR TITLE
Fix install from archive with new version

### DIFF
--- a/playbooks/initial_setup.yaml
+++ b/playbooks/initial_setup.yaml
@@ -22,28 +22,48 @@
     - name: check connectivity
       ansible.builtin.import_role:
         name: ydb_platform.ydb.check_connectivity
+      tags:
+        - checks
 
     - name: setup packages
       ansible.builtin.import_role:
         name: ydb_platform.ydb.packages
+      tags:
+        - setup
+        - packages
 
     - name: configure system
       ansible.builtin.import_role:
         name: ydb_platform.ydb.system
+      tags:
+        - setup
+        - system
 
     - name: setup ydb
       ansible.builtin.import_role:
         name: ydb_platform.ydb.ydbd
+      tags:
+        - setup
+        - binaries
     
     - name: setup fq-connector
       ansible.builtin.import_role:
         name: ydb_platform.ydb.ydb_fq_connector
       when: ydb_install_fq_connector | default(false)
+      tags:
+        - setup
 
     - name: setup ydb static nodes
       ansible.builtin.import_role:
         name: ydb_platform.ydb.ydbd_static
+      tags:
+        - setup
+        - static
+        - storage
 
     - name: setup ydb dynamic nodes
       ansible.builtin.import_role:
         name: ydb_platform.ydb.ydbd_dynamic
+      tags:
+        - setup
+        - dynamic

--- a/roles/install_ydbd/tasks/install_ydb_from_version.yaml
+++ b/roles/install_ydbd/tasks/install_ydb_from_version.yaml
@@ -5,6 +5,7 @@
 - name: Set local path to ydb_archive variable
   set_fact:
     ydb_archive: "{{ ydb_archive_dest }}ydbd-{{ ydb_version }}-linux-amd64.tar.gz"
+  when: ydb_archive is not defined
 
 - name: check if YDB release archive present
   delegate_to: 127.0.0.1

--- a/roles/install_ydbd/tasks/install_ydb_using_binary.yaml
+++ b/roles/install_ydbd/tasks/install_ydb_using_binary.yaml
@@ -35,6 +35,7 @@
     dest: "{{ ydb_dir }}/release/{{ ydb_version }}/bin/ydbd"
     mode: 0755
     follow: true
+    force: "{{ ydb_force_update }}"
 
 - name: copy YDB cli binary file
   ansible.builtin.copy:
@@ -42,6 +43,7 @@
     dest: "{{ ydb_dir }}/release/{{ ydb_version }}/bin/ydb"
     mode: 0755
     follow: true
+    force: "{{ ydb_force_update }}"
 
 - name: Symlink the YDB binaries
   file: path="{{ ydb_dir }}/bin"
@@ -49,10 +51,5 @@
         state=link
         force=yes
 
-- name: Create the YDB CLI default binary directory
-  file: state=directory path={{ ydb_dir }}/home/ydb/bin recurse=true group=ydb owner=ydb mode='0700'
 
-- name: Disable YDB CLI version checks
-  copy: src=ydb-cli-config.json dest={{ ydb_dir }}/home/ydb/bin/config.json group=ydb owner=ydb mode='0644'
-  register: ydb_is_installed
 

--- a/roles/install_ydbd/tasks/main.yaml
+++ b/roles/install_ydbd/tasks/main.yaml
@@ -23,7 +23,7 @@
   - name: download and install YDB server binary package from a release version number
     import_tasks:
       file: install_ydb_from_version.yaml
-    when: ydb_version is defined and ydbd_binary is not defined
+    when: ydb_version is defined and ydbd_binary is not defined and ydb_archive is not defined 
 
   - name: install YDB server binary package from source code
     import_tasks:
@@ -34,3 +34,10 @@
     import_tasks:
       file: install_ydb_using_binary.yaml
     when: ydbd_binary is defined and ydb_cli_binary is defined
+
+- name: Create the YDB CLI default binary directory
+  file: state=directory path={{ ydb_dir }}/home/ydb/bin recurse=true group=ydb owner=ydb mode='0700'
+
+- name: Disable YDB CLI version checks
+  copy: src=ydb-cli-config.json dest={{ ydb_dir }}/home/ydb/bin/config.json group=ydb owner=ydb mode='0644'
+  register: ydb_is_installed


### PR DESCRIPTION
Fix problem with installation from archive.

Current behaviour:

1. Take the archive, get the version from it.
2. Create the archive name based on the version. 
3. Try to install YDB using the archive.

This algorithm does not work with an archive where the version differs from the archive name.

New behaviour:

1. Get the archive and the version from the archive. 
2. Skip the step of setting the archive name and try to install YDB.