### PR TITLE
Update port_listner.py

### DIFF
--- a/roles/check_connectivity/files/port_listner.py
+++ b/roles/check_connectivity/files/port_listner.py
@@ -52,10 +52,10 @@ def main():
     threads = []
 
     for port in ports:
-        thread = threading.Thread(target=listen_port4, args=(port,))
+        thread = threading.Thread(target=listen_port6, args=(port,))
         threads.append(thread)
         thread.start()
-        thread = threading.Thread(target=listen_port6, args=(port,))
+        thread = threading.Thread(target=listen_port4, args=(port,))
         threads.append(thread)
         thread.start()
 


### PR DESCRIPTION
I tested the script on servers with ipv6 only, and the following picture is constantly observed there # netstat -nlp | grep -E “(2135|2136|8765|19001)”
tcp 0 0 0.0.0.0.0:8765 0.0.0.0.0:* LISTEN 2501618/python3 tcp 0 0.0.0.0.0:2136 0.0.0.0.0:* LISTEN 2501618/python3 tcp 0 0.0.0.0.0:19001 0.0.0.0.0:* LISTEN 2501618/python3 tcp6 0 0 0 :::2135 :::* LISTEN 2501618/python3

The easiest way to solve the problem in a fix