### PR TITLE
Tags for some actions

### DIFF
--- a/roles/ydbd_static/tasks/main.yaml
+++ b/roles/ydbd_static/tasks/main.yaml
@@ -384,6 +384,8 @@
   any_errors_fatal: true
   become: true
   become_user: ydb
+  tags:
+    - discovery
 
 - name: wait for ydb healthcheck switch to "GOOD" status
   ydb_platform.ydb.wait_healthcheck:
@@ -400,6 +402,8 @@
   delay: 10
   become: true
   become_user: ydb
+  tags:
+    - healthcheck
 
 - name: set cluster root password
   ydb_platform.ydb.set_user_password:


### PR DESCRIPTION
Now we have tags:
discovery
healthcehck

They can be used to skip them during install with --skip-tags option