### PR TITLE
Fix IO redirection for check_connectivity tasks

### DIFF
--- a/roles/check_connectivity/tasks/main.yaml
+++ b/roles/check_connectivity/tasks/main.yaml
@@ -19,17 +19,17 @@
   ignore_errors: True
 
 - name: Start script to listen YDB ports IPv4/IPv6
-  shell: "nohup nc -4 -6 -l {{ item }} -k > /dev/null &"
+  shell: "nohup nc -4 -6 -l {{ item }} -k </dev/null >/dev/null 2>&1 &"
   with_items: 
     - "{{ ydb_ports }}"
 
 - name: Start script to listen YDB ports IPv6
-  shell: "nohup nc -6 -l {{ item }} -k  > /dev/null &"
+  shell: "nohup nc -6 -l {{ item }} -k </dev/null >/dev/null 2>&1 &"
   with_items: 
     - "{{ ydb_ports }}"
 
 - name: Start script to listen YDB ports IPv4
-  shell: "nohup nc -4 -l {{ item }} -k  > /dev/null &"
+  shell: "nohup nc -4 -l {{ item }} -k </dev/null >/dev/null 2>&1 &"
   with_items: 
     - "{{ ydb_ports }}"
 


### PR DESCRIPTION
The missing stderr redirection causes task hangs on Debian 12 and Ubuntu 22.04. Added the required redirection.