### PR TITLE
YDBOPS-12422: Change restart

### DIFF
--- a/playbooks/update_config.yaml
+++ b/playbooks/update_config.yaml
@@ -52,6 +52,7 @@
     set_fact:
       ydb_config_v2: "{{ ydb_config_v2 | default(ydb_version is defined and ydb_version is version('25.0', '>=')) }}"
     run_once: true
+    when: ydb_config_v2 is not defined
   tags:
     - storage
     - static

--- a/roles/preflight/tasks/main.yaml
+++ b/roles/preflight/tasks/main.yaml
@@ -33,7 +33,6 @@
 - name: set collection level constants
   set_fact:
     ydb_dir: /opt/ydb
-    ydb_config_v2: false
 
 - name: Check current user
   ansible.builtin.command: whoami

--- a/roles/ydbd/defaults/main.yaml
+++ b/roles/ydbd/defaults/main.yaml
@@ -1,1 +1,2 @@
 ydb_transparent_hugepages_enable: true
+ydb_config_v2: false

--- a/roles/ydbd_rolling_static/tasks/check_static.yaml
+++ b/roles/ydbd_rolling_static/tasks/check_static.yaml
@@ -23,3 +23,5 @@
     token: "{{ ydb_credentials.token }}"
     enforce_user_token_requirement: "{{ ydb_enforce_user_token_requirement }}"
   run_once: true
+  tags:
+    - healthcheck

--- a/roles/ydbd_rolling_static/tasks/main.yaml
+++ b/roles/ydbd_rolling_static/tasks/main.yaml
@@ -31,6 +31,7 @@
   when: ydbops_local|bool
   block:
     - name: Check ydbops is present
+      delegate_to: 127.0.0.1
       stat:
         path: "{{ ansible_config_file | dirname }}/bin/ydbops"
       register: ydbops_stat
@@ -71,7 +72,7 @@
       run_once: true
       ydb_platform.ydb.restart_storage:
         ydbops_bin: "{{ ansible_config_file | dirname }}/bin/ydbops"
-        ydbops_endpoint: "grpcs://{{ groups['ydb'] | default(groups['all']) | flatten(levels=1) | first }}:2135"
+        ydbops_endpoint: "grpcs://{{ ydb_brokers | default(groups['ydb']) | flatten(levels=1) | first }}:2135"
         ssh_args: "ssh {{ ansible_ssh_common_args }} -l {{ ansible_user }} -i {{ ansible_ssh_private_key_file }}"
         ca_file: "{{ ydb_tls_dir }}/ca.crt"
         token: "{{ ydb_credentials.token }}"
@@ -85,7 +86,7 @@
       run_once: true
       ydb_platform.ydb.restart_storage:
         ydbops_bin: "{{ ansible_config_file | dirname }}/bin/ydbops"
-        ydbops_endpoint: "grpcs://{{ groups['ydb'] | default(groups['all']) | flatten(levels=1) | first }}:2135"
+        ydbops_endpoint: "grpcs://{{ ydb_brokers | default(groups['ydb']) | flatten(levels=1) | first }}:2135"
         ssh_args: "ssh {{ ansible_ssh_common_args }} -l {{ ansible_user }} -i {{ ansible_ssh_private_key_file }}"
         ca_file: "{{ ydb_tls_dir }}/ca.crt"
         token: "{{ ydb_credentials.token }}"
@@ -126,7 +127,7 @@
     - name: "run ydbops to gracefully restart the cluster, it takes a long time"
       ydb_platform.ydb.restart_storage:
         ydbops_bin: "{{ ydb_dir }}/bin/ydbops"
-        ydbops_endpoint: "grpcs://{{ play_hosts | flatten(levels=1) | first }}:2135"
+        ydbops_endpoint: "grpcs://{{ ydb_brokers | default(groups['ydb']) | flatten(levels=1) | first }}:2135"
         ssh_args: "bash"
         ca_file: "{{ ydb_dir }}/certs/ca.crt"
         token: "{{ ydb_credentials.token }}"
@@ -136,7 +137,7 @@
 
 - name: ydb storage check
   include_tasks: "check_static.yaml"
-  loop: "{{ groups['ydb'] | default(groups['all']) | flatten(levels=1) }}"
+  loop: "{{ brokers | default(groups['ydb']) | flatten(levels=1) }}"
   loop_control:
     loop_var: snode_name
   run_once: true

--- a/roles/ydbd_static/defaults/main.yaml
+++ b/roles/ydbd_static/defaults/main.yaml
@@ -6,3 +6,4 @@ ydb_storage_update_config: false
 # Default value: false
 ydb_use_dynamic_config: false
 ydb_custom_dynconfig: ydbd-dyn-config.yaml.j2
+ydb_config_v2: false

--- a/roles/ydbd_static/tasks/main.yaml
+++ b/roles/ydbd_static/tasks/main.yaml
@@ -150,6 +150,7 @@
   set_fact:
     ydb_config_v2: "{{ ydb_config_v2 | default(ydb_version is defined and ydb_version is version('25.0', '>=')) }}"
   run_once: true
+  when: ydb_config_v2 is not defined
 
 - name: create static node configuration file
   command: "{{ ydb_dir }}/home/update_config_file.sh ydbd-config.yaml ydbd-config-static.yaml STORAGE {{ ydb_storage_node_cores | default(ydb_cores_static) }}"
@@ -187,7 +188,7 @@
     ydbd_bin: "{{ ydb_dir }}/bin/ydbd"
     ld_library_path: "{{ ydb_dir }}/lib"
     ca_file: "{{ ydb_dir }}/certs/ca.crt"
-    endpoint: "grpcs://{{ ydb_front | default(inventory_hostname) }}:2135"
+    endpoint: "grpcs://{{ ydb_brokers | flatten(levels=1) | first }}:2135"
     allow_format: "{{ ydb_allow_format_drives }}"
   with_items: "{{ ydb_disks }}"
   become: true
@@ -250,7 +251,7 @@
     config_dir: "{{ ydb_dir }}/cfg"
     ydb_bin: "{{ ydb_dir }}/bin/ydb"
     ld_library_path: "{{ ydb_dir }}/lib"
-    endpoint: "grpcs://{{ ydb_front | default(inventory_hostname) }}:2135"
+    endpoint: "grpcs://{{ ydb_brokers | flatten(levels=1) | first }}:2135"
     database: "/{{ ydb_domain }}"
   become: true
   become_user: ydb
@@ -295,7 +296,7 @@
 - name: wait for YDB TLS service to be ready
   wait_for:
     port: 2135
-    host: "{{ ydb_front | default(inventory_hostname) }}"
+    host: "{{ ydb_brokers | flatten(levels=1) | first }}"
     timeout: 120
     delay: 5
   run_once: true
@@ -309,7 +310,7 @@
   ydb_platform.ydb.get_token:
     ydb_bin: "{{ ydb_dir }}/bin/ydb"
     ca_file: "{{ ydb_dir }}/certs/ca.crt"
-    endpoint: "grpcs://{{ ydb_front | default(inventory_hostname) }}:2135"
+    endpoint: "grpcs://{{ ydb_brokers | flatten(levels=1) | first }}:2135"
     database: "/{{ ydb_domain }}"
     user: "{{ ydb_user }}"
     password: "{{ ydb_password }}"
@@ -331,7 +332,7 @@
     ld_library_path: "{{ ydb_dir }}/lib"
     dstool_bin: "{{ ydb_dir }}/bin/ydb-dstool"
     ca_file: "{{ ydb_dir }}/certs/ca.crt"
-    endpoint: "grpcs://{{ ydb_front | default(inventory_hostname) }}:2135"
+    endpoint: "grpcs://{{ ydb_brokers | flatten(levels=1) | first }}:2135"
     database: "/{{ ydb_domain }}"
     token: "{{ root_token.token | default('') }}"
     use_config_v2: "false"
@@ -350,7 +351,7 @@
     ld_library_path: "{{ ydb_dir }}/lib"
     dstool_bin: "{{ ydb_dir }}/bin/ydb-dstool"
     ca_file: "{{ ydb_dir }}/certs/ca.crt"
-    endpoint: "grpcs://{{ ydb_front | default(inventory_hostname) }}:2135"
+    endpoint: "grpcs://{{ ydb_brokers | flatten(levels=1) | first }}:2135"
     use_config_v2: "true"
   register: init_storage_v2
   run_once: true
@@ -361,7 +362,7 @@
   ydb_platform.ydb.get_token:
     ydb_bin: "{{ ydb_dir }}/bin/ydb"
     ca_file: "{{ ydb_dir }}/certs/ca.crt"
-    endpoint: "grpcs://{{ ydb_front | default(inventory_hostname) }}:2135"
+    endpoint: "grpcs://{{ ydb_brokers | flatten(levels=1) | first }}:2135"
     database: "/{{ ydb_domain }}"
     user: "{{ ydb_user }}"
     password: "{{ ydb_password }}"
@@ -378,7 +379,7 @@
   ydb_platform.ydb.wait_discovery:
     ydb_bin: "{{ ydb_dir }}/bin/ydb"
     ca_file: "{{ ydb_dir }}/certs/ca.crt"
-    endpoint: "grpcs://{{ ydb_front | default(inventory_hostname) }}:2135"
+    endpoint: "grpcs://{{ ydb_brokers | flatten(levels=1) | first }}:2135"
     database: "/{{ ydb_domain }}"
     token: "{{ ydb_credentials.token }}"
   any_errors_fatal: true
@@ -391,7 +392,7 @@
   ydb_platform.ydb.wait_healthcheck:
     ydb_bin: "{{ ydb_dir }}/bin/ydb"
     ca_file: "{{ ydb_dir }}/certs/ca.crt"
-    endpoint: "grpcs://{{ ydb_front | default(inventory_hostname) }}:2135"
+    endpoint: "grpcs://{{ ydb_brokers | flatten(levels=1) | first }}:2135"
     database: "/{{ ydb_domain }}"
     token: "{{ ydb_credentials.token }}"
     enforce_user_token_requirement: "{{ ydb_enforce_user_token_requirement }}"
@@ -409,7 +410,7 @@
   ydb_platform.ydb.set_user_password:
     ydb_bin: "{{ ydb_dir }}/bin/ydb"
     ca_file: "{{ ydb_dir }}/certs/ca.crt"
-    endpoint: "grpcs://{{ ydb_front | default(inventory_hostname) }}:2135"
+    endpoint: "grpcs://{{ ydb_brokers | flatten(levels=1) | first }}:2135"
     database: "/{{ ydb_domain }}"
     user: "{{ ydb_user }}"
     new_password: "{{ ydb_password }}"
@@ -435,7 +436,7 @@
         ydb_bin: "{{ ydb_dir }}/bin/ydb"
         ld_library_path: "{{ ydb_dir }}/lib"
         ca_file: "{{ ydb_dir }}/certs/ca.crt"
-        endpoint: "grpcs://{{ inventory_hostname }}:2135"
+        endpoint: "grpcs://{{ ydb_brokers | flatten(levels=1) | first }}:2135"
         database: "/{{ ydb_domain }}"
         token: "{{ ydb_credentials.token }}"
       register: ydb_dynconfig_info
@@ -448,7 +449,7 @@
         ydb_bin: "{{ ydb_dir }}/bin/ydb"
         ld_library_path: "{{ ydb_dir }}/lib"
         ca_file: "{{ ydb_dir }}/certs/ca.crt"
-        endpoint: "grpcs://{{ inventory_hostname }}:2135"
+        endpoint: "grpcs://{{ ydb_brokers | flatten(levels=1) | first }}:2135"
         database: "/{{ ydb_domain }}"
         user: "{{ ydb_user }}"
         token: "{{ ydb_credentials.token }}"

--- a/roles/ydbd_static/tasks/main.yaml
+++ b/roles/ydbd_static/tasks/main.yaml
@@ -384,6 +384,8 @@
   any_errors_fatal: true
   become: true
   become_user: ydb
+  tags:
+    - discovery
 
 - name: wait for ydb healthcheck switch to "GOOD" status
   ydb_platform.ydb.wait_healthcheck:
@@ -400,6 +402,8 @@
   delay: 10
   become: true
   become_user: ydb
+  tags:
+    - healthcheck
 
 - name: set cluster root password
   ydb_platform.ydb.set_user_password:


### PR DESCRIPTION
Previous behavior: take a record from inventory and use it as a FQDN.
Problem: in case of using short FQDN names it  makes restart impossible.

Solution: replace inventory_hostname / host groups with `ydb_brokers` variable.