### PR TITLE
Add goal to run collection documentation linting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,3 +22,6 @@ run:
 test:
 	python3 -m unittest discover -v tests/unit
 .PHONY: test
+
+lint-collection-docs:  ## Lint ansible collection documentation
+	uv run --isolated --no-project --with-requirements requirements-docs.txt antsibull-docs lint-collection-docs --plugin-docs --validate-collection-refs=self --disallow-unknown-collection-refs .

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,0 +1,1 @@
+antsibull-docs==2.24.0


### PR DESCRIPTION
This is a handy tool to lint all documentation data for plugins and modules. Without it collection doc website build will fail.