### PR TITLE
[codex] Fix ydb static deployment checks

### DIFF
--- a/playbooks/healthcheck.yaml
+++ b/playbooks/healthcheck.yaml
@@ -58,11 +58,9 @@
         database: "/{{ ydb_domain }}"
         token: "{{ ydb_credentials.token }}"
         enforce_user_token_requirement: "{{ ydb_enforce_user_token_requirement }}"
+        timeout: "{{ ydb_healthcheck_timeout | default(600) }}"
       run_once: true
       register: healthcheck_result
-      until: healthcheck_result is succeeded
-      retries: 30
-      delay: 10
       become: true
       become_user: "{{ ydb_host_user }}"
       tags:

--- a/playbooks/migrate_to_v1.yaml
+++ b/playbooks/migrate_to_v1.yaml
@@ -454,11 +454,9 @@
       database: "/{{ ydb_domain }}"
       token: "{{ ydb_credentials.token }}"
       enforce_user_token_requirement: "{{ ydb_enforce_user_token_requirement }}"
+      timeout: "{{ ydb_healthcheck_timeout | default(600) }}"
     run_once: true
     register: healthcheck_result
-    until: healthcheck_result is succeeded
-    retries: 30
-    delay: 10
     tags:
       - healthcheck
       - check

--- a/playbooks/migrate_to_v2.yaml
+++ b/playbooks/migrate_to_v2.yaml
@@ -523,11 +523,9 @@
       database: "/{{ ydb_domain }}"
       token: "{{ ydb_credentials.token }}"
       enforce_user_token_requirement: "{{ ydb_enforce_user_token_requirement }}"
+      timeout: "{{ ydb_healthcheck_timeout | default(600) }}"
     run_once: true
     register: healthcheck_result
-    until: healthcheck_result is succeeded
-    retries: 30
-    delay: 10
     tags:
       - healthcheck
       - check

--- a/playbooks/update_executable.yaml
+++ b/playbooks/update_executable.yaml
@@ -65,6 +65,17 @@
       tags:
         - no_restart
 
+    - name: Ensure local bin directory exists for ydb-dstool download
+      delegate_to: 127.0.0.1
+      run_once: true
+      ansible.builtin.file:
+        path: "{{ ansible_config_file | dirname }}/bin"
+        state: directory
+        mode: 0755
+      when: not ydb_dstool_exists.stat.exists and ydb_dstool_binary is not defined
+      tags:
+        - no_restart
+
     - name: Install ydb-dstool (from URL) to localhost
       delegate_to: 127.0.0.1
       run_once: true

--- a/plugins/modules/init_node_config.py
+++ b/plugins/modules/init_node_config.py
@@ -1,6 +1,7 @@
 import json
 from logging import basicConfig
 import os
+import shutil
 import tempfile
 import yaml
 
@@ -17,12 +18,42 @@ DOCUMENTATION = r'''
         Create initial config for a node with V2 configuration
 '''
 
-def check_node_config_exists(config_dir, result):
-    """Check if node configuration already exists"""
+def prepare_node_config(config_file):
+    """Read a config file and add metadata required by node config init."""
+    with open(config_file, 'r') as f:
+        config = yaml.safe_load(f)
+
+    config['metadata'] = {
+        'kind': 'MainConfig',
+        'cluster': '',
+        'version': 0
+    }
+    return config
+
+
+def dump_config(config):
+    return yaml.safe_dump(config, default_flow_style=False, sort_keys=True)
+
+
+def check_node_config_current(config_file, config_dir, result):
+    """Check if node configuration already matches the requested config."""
     config_path = os.path.join(config_dir, 'config.yaml')
-    if os.path.exists(config_path):
+    if not os.path.exists(config_path):
+        return False
+
+    desired_config = prepare_node_config(config_file)
+    try:
+        with open(config_path, 'r') as f:
+            current_config = yaml.safe_load(f)
+    except Exception as e:
+        result['msg'] = f'failed to read existing node configuration: {e}'
+        return False
+
+    if dump_config(current_config) == dump_config(desired_config):
         result['msg'] = 'node configuration already exists'
         return True
+
+    result['msg'] = 'node configuration exists but differs from requested config'
     return False
 
 
@@ -31,16 +62,7 @@ def init_node_config(ydb_cli, config_file, config_dir, result):
 
     temp_file = None
     try:
-        # Read the original config file
-        with open(config_file, 'r') as f:
-            original_config = yaml.safe_load(f)
-
-        # Create the initial metadata structure
-        original_config['metadata'] = {
-            'kind': 'MainConfig',
-            'cluster': '',
-            'version': 0
-        }
+        original_config = prepare_node_config(config_file)
 
         # Create temporary file
         temp_fd, temp_file = tempfile.mkstemp(suffix='.yaml', text=True)
@@ -89,15 +111,26 @@ def main():
         config_file = module.params.get('config_file')
         config_dir = module.params.get('config_dir')
 
-        # Check if node configuration already exists
-        if check_node_config_exists(config_dir, result):
+        config_path = os.path.join(config_dir, 'config.yaml')
+        backup_path = config_path + '.ansible.bak'
+
+        # Check if node configuration already matches the requested config
+        if check_node_config_current(config_file, config_dir, result):
             module.exit_json(**result)
+
+        if os.path.exists(config_path):
+            shutil.move(config_path, backup_path)
 
         # Initialize node configuration
         success = init_node_config(ydb_cli, config_file, config_dir, result)
 
         if not success:
+            if os.path.exists(backup_path):
+                shutil.move(backup_path, config_path)
             module.fail_json(**result)
+
+        if os.path.exists(backup_path):
+            os.unlink(backup_path)
 
         result['changed'] = True
         module.exit_json(**result)

--- a/plugins/modules/init_storage.py
+++ b/plugins/modules/init_storage.py
@@ -20,6 +20,8 @@ def check_storage_initialization(ydb_dstool, result):
     rc, stdout, stderr = ydb_dstool(['--http-timeout 5', 'box', 'list', '--format=json'])
     if rc != 0:
         # If dstool box list fails, assume storage is not initialized
+        result['dstool_storage_check_stdout'] = stdout
+        result['dstool_storage_check_stderr'] = stderr
         return False, False
 
     try:
@@ -104,6 +106,12 @@ def init_storage_using_config_v2(ydb_cli, ydb_dir, enforce_user_token_requiremen
         cmd = ['--client-cert-file',f'{ydb_dir}/certs/node.crt','--client-cert-key-file',f'{ydb_dir}/certs/node.key', '--assume-yes', 'admin', 'cluster', 'bootstrap', '--uuid', str(uuid.uuid4())]
     rc, stdout, stderr = ydb_cli(cmd)
     if rc != 0:
+        combined_output = f'{stdout}\n{stderr}'.lower()
+        if 'already bootstrapped' in combined_output:
+            result['msg'] = 'storage already initialized'
+            result['stdout'] = stdout
+            result['stderr'] = stderr
+            return True
         result['msg'] = 'bootstrap failed'
         result['cmd'] = ' '.join(ydb_cli.common_options + cmd)
         result['stdout'] = stdout

--- a/plugins/modules/wait_healthcheck.py
+++ b/plugins/modules/wait_healthcheck.py
@@ -13,6 +13,17 @@ DOCUMENTATION = r'''
         Wait until healthcheck becomes GOOD
 '''
 
+def collect_issue_messages(data, limit=5):
+    messages = []
+    for issue in data.get('issue_log', []):
+        message = issue.get('message')
+        if message:
+            messages.append(message)
+        if len(messages) >= limit:
+            break
+    return messages
+
+
 def main():
     argument_spec=dict(
         timeout=dict(type='int', default=180),
@@ -67,7 +78,8 @@ def main():
                 time.sleep(5)
                 continue
             if self_check_result not in ("GOOD", "DEGRADED"):
-                module.log(f'self check result: {self_check_result}: {data}')
+                issue_messages = collect_issue_messages(data)
+                module.log(f'self check result: {self_check_result}, issue messages: {issue_messages}')
                 time.sleep(5)
                 continue
             result['msg'] = f'ydb healthcheck result "{self_check_result}": {data}'
@@ -82,7 +94,8 @@ def main():
                     failure_msg += f', stdout="{last_stdout}", stderr="{last_stderr}"'
                 elif last_data:
                     if last_self_check_result:
-                        failure_msg += f', result="{last_self_check_result}", data={last_data}'
+                        issue_messages = collect_issue_messages(last_data)
+                        failure_msg += f', result="{last_self_check_result}", issue_messages={issue_messages}, data={last_data}'
                     else:
                         failure_msg += f', stdout="{last_stdout}"'
                 else:

--- a/roles/ydbd_rolling_static/tasks/check_static.yaml
+++ b/roles/ydbd_rolling_static/tasks/check_static.yaml
@@ -22,6 +22,7 @@
     database: "/{{ ydb_domain }}"
     token: "{{ ydb_credentials.token }}"
     enforce_user_token_requirement: "{{ ydb_enforce_user_token_requirement }}"
+    timeout: "{{ ydb_healthcheck_timeout | default(600) }}"
   run_once: true
   tags:
     - healthcheck

--- a/roles/ydbd_static/defaults/main.yaml
+++ b/roles/ydbd_static/defaults/main.yaml
@@ -9,4 +9,5 @@ ydb_custom_dynconfig: ydbd-dyn-config.yaml.j2
 ydb_config_v2: false
 ydb_host_user: ydb
 ydb_host_group: ydb
-
+ydb_healthcheck_timeout: 600
+ydb_time_sync_check: true

--- a/roles/ydbd_static/tasks/main.yaml
+++ b/roles/ydbd_static/tasks/main.yaml
@@ -128,6 +128,45 @@
   loop:
     - ydb_password
 
+- name: validate ydb_password characters
+  no_log: true
+  ansible.builtin.assert:
+    that:
+      - ydb_password is match('^[A-Za-z0-9]+$')
+    fail_msg: ydb_password must contain only latin letters and digits
+
+- name: check time synchronization with timedatectl
+  ansible.builtin.command: timedatectl show -p NTPSynchronized --value
+  register: ydb_timedatectl_sync
+  changed_when: false
+  failed_when: false
+  when: ydb_time_sync_check|bool
+  tags:
+    - checks
+    - time_sync
+
+- name: check time synchronization with chronyc
+  ansible.builtin.command: chronyc tracking
+  register: ydb_chronyc_tracking
+  changed_when: false
+  failed_when: false
+  when:
+    - ydb_time_sync_check|bool
+    - ydb_timedatectl_sync.stdout | trim != 'yes'
+  tags:
+    - checks
+    - time_sync
+
+- name: fail if time is not synchronized
+  ansible.builtin.assert:
+    that:
+      - ydb_timedatectl_sync.stdout | trim == 'yes' or ('Leap status     : Normal' in (ydb_chronyc_tracking.stdout | default('')))
+    fail_msg: "Host time is not synchronized. Fix NTP/chrony before YDB bootstrap to avoid CLOCK_SKEW healthcheck failures."
+  when: ydb_time_sync_check|bool
+  tags:
+    - checks
+    - time_sync
+
 - name: Add the disk formatting script
   template: src=safe_format.j2 dest={{ ydb_dir }}/home/safe_format.sh mode='755'
 
@@ -259,6 +298,15 @@
     dest: "{{ ydb_dir }}/bin/ydb-dstool"
     mode: 0755
   when: not ydb_dstool_exists.stat.exists and ydb_dstool_binary is defined
+
+- name: Ensure local bin directory exists for ydb-dstool download
+  delegate_to: 127.0.0.1
+  run_once: true
+  ansible.builtin.file:
+    path: "{{ ansible_config_file | dirname }}/bin"
+    state: directory
+    mode: 0755
+  when: not ydb_dstool_exists.stat.exists and ydb_dstool_binary is not defined
 
 - name: Install ydb-dstool (from URL) to localhost
   delegate_to: 127.0.0.1
@@ -395,11 +443,9 @@
     database: "/{{ ydb_domain }}"
     token: "{{ ydb_credentials.token }}"
     enforce_user_token_requirement: "{{ ydb_enforce_user_token_requirement }}"
+    timeout: "{{ ydb_healthcheck_timeout }}"
   run_once: true
   register: healthcheck_result
-  until: healthcheck_result is succeeded
-  retries: 30
-  delay: 10
   become: true
   become_user: "{{ ydb_host_user }}"
   tags:


### PR DESCRIPTION
## What changed

- Treat `already bootstrapped` bootstrap output as successful storage initialization for config v2.
- Create the local `bin` directory before downloading `ydb-dstool`.
- Add early `ydb_password` character validation.
- Add a pre-bootstrap time synchronization check to fail before CLOCK_SKEW healthcheck loops.
- Use a single bounded healthcheck timeout and include first issue log messages in failure diagnostics.
- Regenerate v2 node config when the desired config differs from existing `config.yaml`.

## Why

These changes apply the ydb-only playbook recommendations for the `ydb_platform.ydb` collection. They avoid repeated bootstrap failures with client-cert, make dstool URL installs work on fresh controller directories, surface clock skew earlier, and prevent stale node config from surviving inventory/config changes.

## Validation

- `PYTHONPYCACHEPREFIX=/tmp/ydb-ansible-pycache python3 -m py_compile plugins/modules/init_storage.py plugins/modules/init_node_config.py plugins/modules/wait_healthcheck.py`
- YAML parse check for changed playbooks/role task files with `yaml.safe_load`
- `git diff --check`

`pytest` and `ansible-playbook --syntax-check` were not run because this environment does not have `pytest` or `ansible-playbook` installed.