### PR TITLE
Add update_certs playbook for TLS certificate file updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,25 @@ Notes:
     * first to deploy the ca.crt file, containing both new and old CA certificates;
     * second to deploy the fresh server keys and certificates signed by the new CA certificate.
 
+To update only TLS certificate files without reinstalling binaries or changing the cluster configuration, use the dedicated playbook:
+
+```bash
+ansible-playbook ydb_platform.ydb.update_certs
+```
+
+This playbook copies certificate files to all nodes over SSH and does not restart YDB processes. After updating certificates, restart the cluster to apply the changes:
+
+```bash
+ansible-playbook ydb_platform.ydb.restart
+```
+
+If the cluster is unavailable over TLS (for example, when certificates have expired), restart it with:
+
+```bash
+ansible-playbook ydb_platform.ydb.stop_cluster
+ansible-playbook ydb_platform.ydb.start_cluster
+```
+
 ### What is actually done by the playbooks?
 
 #### Actions executed for installing YDB nodes
@@ -167,6 +186,7 @@ For `ydb_config_v2: false`:
 * ydb_platform.ydb.binaries_all - Install YDB binaries to all nodes
 * ydb_platform.ydb.binaries_static - Install YDB binaries to all static/storage nodes
 * ydb_platform.ydb.binaries_dynamic - Install YDB binaries to all dynamic nodes
+* ydb_platform.ydb.update_certs - Copy TLS certificates to all nodes
 * ydb_platform.ydb.restart - Restart static (weak mode) and after that dynamic nodes
 * ydb_platform.ydb.rolling_restart_static - Restart static nodes in weak mode
 * ydb_platform.ydb.rolling_restart_dynamic - Restart dynamic nodes

--- a/playbooks/update_certs.yaml
+++ b/playbooks/update_certs.yaml
@@ -1,0 +1,37 @@
+---
+# PLAYBOOK: ydb_platform.ydb.update_certs
+# PROPOSE : Copy TLS certificate files to all YDB cluster nodes
+#
+# EXAMPLE:
+#
+# Update certificates on all nodes
+#   ansible-playbook ydb_platform.ydb.update_certs
+#
+# Update certificates on selected hosts
+#   ansible-playbook ydb_platform.ydb.update_certs -l <HostFQDN>
+#
+# NOTES:
+#   This playbook only copies certificate files and does not restart YDB processes.
+#   After updating certificates, restart the cluster to apply changes, for example:
+#     ansible-playbook ydb_platform.ydb.restart
+#   or, if the cluster is unavailable over TLS:
+#     ansible-playbook ydb_platform.ydb.stop_cluster
+#     ansible-playbook ydb_platform.ydb.start_cluster
+
+- name: Check if required variables are defined
+  hosts: "{{ ansible_play_hosts | default('ydb') }}"
+
+  tasks:
+    - ansible.builtin.assert:
+        that:
+          - lookup('vars', item, default=None) is not none
+        fail_msg: "Either {{ item }} variable is required"
+      loop:
+        - ydb_tls_dir
+
+- hosts: "{{ ansible_play_hosts | default('ydb') }}"
+  become: true
+
+  roles:
+    - role: preflight
+    - role: ydbd_certs

--- a/roles/ydbd/tasks/main.yaml
+++ b/roles/ydbd/tasks/main.yaml
@@ -97,38 +97,8 @@
         ydb_tls_dir: "{{ ansible_config_file | dirname }}/files/TLS/certs/{{ current_time }}"
 
 - name: setup certificates
-  block:
-    - name: copy the TLS ca.crt
-      copy:
-        src: "{{ ydb_tls_dir }}/ca.crt"
-        dest: "{{ ydb_dir }}/certs/ca.crt"
-        owner: root
-        group: certs
-        mode: 0440
-
-    - name: copy the TLS node.crt
-      copy:
-        src: "{{ ydb_tls_dir }}/{{ inventory_hostname_short }}/node.crt"
-        dest: "{{ ydb_dir }}/certs/node.crt"
-        owner: root
-        group: certs
-        mode: 0440
-
-    - name: copy the TLS node.key
-      copy:
-        src: "{{ ydb_tls_dir }}/{{ inventory_hostname_short }}/node.key"
-        dest: "{{ ydb_dir }}/certs/node.key"
-        owner: root
-        group: certs
-        mode: 0440
-
-    - name: copy the TLS web.pem
-      copy:
-        src: "{{ ydb_tls_dir }}/{{ inventory_hostname_short }}/web.pem"
-        dest: "{{ ydb_dir }}/certs/web.pem"
-        owner: root
-        group: certs
-        mode: 0440
+  ansible.builtin.import_role:
+    name: ydb_platform.ydb.ydbd_certs
 
 - name: install ydbd
   ansible.builtin.import_role:

--- a/roles/ydbd_certs/meta/main.yaml
+++ b/roles/ydbd_certs/meta/main.yaml
@@ -1,0 +1,2 @@
+---
+allow_duplicates: true

--- a/roles/ydbd_certs/tasks/main.yaml
+++ b/roles/ydbd_certs/tasks/main.yaml
@@ -1,0 +1,45 @@
+---
+- name: ensure certs group exists
+  group:
+    name: certs
+    system: true
+
+- name: Create the YDB certs directory
+  file:
+    state: directory
+    path: "{{ ydb_dir }}/certs"
+    group: ydb
+    owner: ydb
+    mode: '0700'
+
+- name: copy the TLS ca.crt
+  copy:
+    src: "{{ ydb_tls_dir }}/ca.crt"
+    dest: "{{ ydb_dir }}/certs/ca.crt"
+    owner: root
+    group: certs
+    mode: 0440
+
+- name: copy the TLS node.crt
+  copy:
+    src: "{{ ydb_tls_dir }}/{{ inventory_hostname_short }}/node.crt"
+    dest: "{{ ydb_dir }}/certs/node.crt"
+    owner: root
+    group: certs
+    mode: 0440
+
+- name: copy the TLS node.key
+  copy:
+    src: "{{ ydb_tls_dir }}/{{ inventory_hostname_short }}/node.key"
+    dest: "{{ ydb_dir }}/certs/node.key"
+    owner: root
+    group: certs
+    mode: 0440
+
+- name: copy the TLS web.pem
+  copy:
+    src: "{{ ydb_tls_dir }}/{{ inventory_hostname_short }}/web.pem"
+    dest: "{{ ydb_dir }}/certs/web.pem"
+    owner: root
+    group: certs
+    mode: 0440


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a dedicated playbook `ydb_platform.ydb.update_certs` that copies TLS certificate files to all YDB cluster nodes over SSH, without reinstalling binaries or changing cluster configuration.

This addresses the gap where `binaries_all` performs a full binary installation and `update_config` requires a live TLS connection to the cluster API.

## Changes

- **New playbook** `playbooks/update_certs.yaml` — copies certificates to all nodes in the `ydb` inventory group
- **New role** `roles/ydbd_certs/` — contains the certificate copy logic (`ca.crt`, `node.crt`, `node.key`, `web.pem`)
- **Refactor** `roles/ydbd/tasks/main.yaml` — reuses `ydbd_certs` role instead of duplicating copy tasks
- **Documentation** — README updated with usage examples and restart instructions

## Usage

```bash
# Copy new certificates to all nodes
ansible-playbook ydb_platform.ydb.update_certs

# Apply changes (cluster must be reachable over TLS)
ansible-playbook ydb_platform.ydb.restart

# Or, if the cluster is unavailable over TLS (e.g. expired certificates)
ansible-playbook ydb_platform.ydb.stop_cluster
ansible-playbook ydb_platform.ydb.start_cluster
```

**Prerequisite:** `ydb_tls_dir` must point to the directory with the new certificate files.

## Notes

- The playbook does **not** restart YDB processes — a separate restart is required for nodes to load the new certificates.
- Works over SSH only, making it suitable for recovery when cluster TLS is broken due to expired certificates.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-23b32525-ab92-4acc-9c62-53dd6b0738cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-23b32525-ab92-4acc-9c62-53dd6b0738cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

